### PR TITLE
Reset (close connection) on periodic reconnect attempts, cleaning up SSL context

### DIFF
--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -149,12 +149,12 @@ module Sensu
         setup_channel(options)
       end
 
-      def periodically_reconnect(delay=1)
+      def periodically_reconnect(delay=2)
         capped_delay = (delay >= 20 ? 20 : delay)
         EM::Timer.new(capped_delay) do
           unless connected?
             reset
-            periodically_reconnect(capped_delay += 3)
+            periodically_reconnect(capped_delay += 2)
             begin
               connect_with_eligible_options do
                 @reconnecting = false


### PR DESCRIPTION
This PR causes the RabbitMQ transport to reset on every periodic reconnect attempt, which includes closing the current connection (if any).
