### PR TITLE
Add :user_id to published messages.

### DIFF
--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -35,7 +35,7 @@ module Sensu
 
       def publish(exchange_type, exchange_name, message, options={}, &callback)
         begin
-          @channel.method(exchange_type.to_sym).call(exchange_name, options).publish(message) do
+          @channel.method(exchange_type.to_sym).call(exchange_name, options).publish(message, :user_id => @connection.settings[:user]) do
             info = {}
             callback.call(info) if callback
           end


### PR DESCRIPTION
This is the first part in addressing https://github.com/sensu/sensu/issues/1118. This makes use of [RabbitMQ's Validated User-ID feature](https://www.rabbitmq.com/validated-user-id.html). With this set, all messages will be published with a `user_id` attribute set. RabbitMQ will validate that the `user_id` matches the username that was used to authenticate, and reject messages that don't. This is a fairly safe change and probably good practice to have.

Feedback welcome.