### PR TITLE
Implemented a deferrable/callback transport API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
   - 2.0.0
   - 2.1.0
-  - jruby-1.7.18
+  - 2.2.0
+  - 2.2.3
+  - 2.3.0
+  - jruby-1.7.23
 services:
   - rabbitmq
   - redis

--- a/lib/sensu/transport.rb
+++ b/lib/sensu/transport.rb
@@ -12,6 +12,8 @@ module Sensu
       #
       # @param transport_name [String] transport name.
       # @param options [Hash] transport options.
+      # @yield [Object] passes initialized and connected connection
+      #   object to the callback/block.
       def connect(transport_name, options={})
         require("sensu/transport/#{transport_name}")
         klass = Base.descendants.detect do |klass|
@@ -20,7 +22,9 @@ module Sensu
         transport = klass.new
         transport.logger = @logger
         transport.connect(options)
-        transport
+        transport.callback do
+          yield(transport)
+        end
       end
     end
   end

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -5,6 +5,11 @@ module Sensu
     class Error < StandardError; end
 
     class Base
+      # Transports are deferrable objects. This is to enable callbacks
+      # to be called in the event the transport calls `succeed()` to
+      # indicate that it has initialized and connected successfully.
+      include EM::Deferrable
+
       # @!attribute [rw] logger
       #   @return [Logger] the Sensu logger object.
       attr_accessor :logger

--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -190,6 +190,7 @@ module Sensu
         @connection.logger = @logger
         @connection.on_open do
           @connection_timeout.cancel
+          succeed
           yield if block_given?
         end
         @connection.on_tcp_connection_loss(&reconnect_callback)
@@ -200,7 +201,7 @@ module Sensu
         @channel = AMQP::Channel.new(@connection)
         @channel.auto_recovery = true
         @channel.on_error do |channel, channel_close|
-          error = Error.new("rabbitmq channel closed")
+          error = Error.new("rabbitmq channel error")
           @on_error.call(error)
         end
         prefetch = 1
@@ -229,6 +230,7 @@ module Sensu
               end
             rescue EventMachine::ConnectionError
             rescue Java::JavaLang::RuntimeException
+            rescue Java::JavaNioChannels::UnresolvedAddressException
             end
           end
         end

--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -8,7 +8,9 @@ require File.join(File.dirname(__FILE__), "patches", "amqp")
 module Sensu
   module Transport
     class RabbitMQ < Base
-      # RabbitMQ connection setup.
+      # RabbitMQ connection setup. The deferred status is set to
+      # `:succeeded` (via `succeed()`) once the connection has been
+      # established.
       #
       # @param options [Hash, String]
       def connect(options={})

--- a/lib/sensu/transport/redis.rb
+++ b/lib/sensu/transport/redis.rb
@@ -14,8 +14,9 @@ module Sensu
         super
       end
 
-      # Redis transport connection setup. This method sets `@options`
-      # and creates a named Redis connection "redis".
+      # Redis transport connection setup. This method sets `@options`,
+      # creates a named Redis connection "redis", and sets the deferred
+      # status to `:succeeded` via `succeed()`.
       #
       # @param options [Hash, String]
       def connect(options={})

--- a/sensu-transport.gemspec
+++ b/sensu-transport.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("eventmachine")
   spec.add_dependency("amq-protocol", "1.9.2")
   spec.add_dependency("amqp", "1.5.0")
-  spec.add_dependency("em-redis-unified", ">= 1.0.0")
+  spec.add_dependency("sensu-redis", ">= 1.0.0")
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/spec/transport_spec.rb
+++ b/spec/transport_spec.rb
@@ -8,22 +8,44 @@ describe "Sensu::Transport" do
   it "can load and connect to the rabbitmq transport" do
     async_wrapper do
       options = {}
-      transport = Sensu::Transport.connect("rabbitmq", options)
-      timer(1) do
+      Sensu::Transport.connect("rabbitmq", options) do |transport|
         expect(transport.connected?).to be(true)
         async_done
       end
     end
   end
 
-  it "can set the transport logger" do
+  it "can load and connect to the redis transport" do
+    async_wrapper do
+      options = {}
+      Sensu::Transport.connect("redis", options) do |transport|
+        expect(transport.connected?).to be(true)
+        async_done
+      end
+    end
+  end
+
+  it "can set the rabbitmq transport logger" do
     async_wrapper do
       logger = Logger.new(STDOUT)
       Sensu::Transport.logger = logger
-      transport = Sensu::Transport.connect("rabbitmq")
-      expect(transport.logger).to eq(logger)
-      expect(transport.logger).to respond_to(:error)
-      async_done
+      Sensu::Transport.connect("rabbitmq") do |transport|
+        expect(transport.logger).to eq(logger)
+        expect(transport.logger).to respond_to(:error)
+        async_done
+      end
+    end
+  end
+
+  it "can set the redis transport logger" do
+    async_wrapper do
+      logger = Logger.new(STDOUT)
+      Sensu::Transport.logger = logger
+      Sensu::Transport.connect("redis") do |transport|
+        expect(transport.logger).to eq(logger)
+        expect(transport.logger).to respond_to(:error)
+        async_done
+      end
     end
   end
 end


### PR DESCRIPTION
This allows the transport API to support backends that require more song 'n dance before they are able to provide a connection object. The new Sensu Redis library supports Sentinel, this PR includes the required changes to transport API in order to support it and other backends like it.

![1201](https://cloud.githubusercontent.com/assets/149630/13892084/3ef2f556-ed12-11e5-8ea6-abc381e1b434.gif)

`transport = Transport.connect()`

is now:

`Transport.connect() do |transport|`