### PR TITLE
Throw an exception when publishing while disconnected

### DIFF
--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -57,11 +57,16 @@ module Sensu
       #   callback/block.
       # @yieldparam info [Hash] contains publish information.
       def publish(type, pipe, message, options={})
-        catch_errors do
-          @channel.method(type.to_sym).call(pipe, options).publish(message) do
-            info = {}
-            yield(info) if block_given?
+        if connected?
+          catch_errors do
+            @channel.method(type.to_sym).call(pipe, options).publish(message) do
+              info = {}
+              yield(info) if block_given?
+            end
           end
+        else
+          info = {:error => "Transport is not connected"}
+          yield(info) if block_given?
         end
       end
 


### PR DESCRIPTION
Fix issue #32 

I suppose ideally the AMQP underlying component should throw an exception or provide an error, but at least this way we do not even try if we know we're disconnected.