### PR TITLE
Implement Transport Base API hostname resolution methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ services:
 notifications:
   irc:
     - "irc.freenode.net#sensu"
-script: "bundle exec rspec . --tag ~ssl --tag ~dns"
+script: "bundle exec rspec . --tag ~ssl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ services:
 notifications:
   irc:
     - "irc.freenode.net#sensu"
-script: "bundle exec rspec . --tag ~ssl"
+script: "nslookup localhost && bundle exec rspec . --tag ~ssl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ services:
 notifications:
   irc:
     - "irc.freenode.net#sensu"
-script: "nslookup localhost && bundle exec rspec . --tag ~ssl"
+script: "cat /etc/hosts && bundle exec rspec . --tag ~ssl ~dns"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ services:
 notifications:
   irc:
     - "irc.freenode.net#sensu"
-script: "cat /etc/hosts && bundle exec rspec . --tag ~ssl ~dns"
+script: "bundle exec rspec . --tag ~ssl --tag ~dns"

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -160,7 +160,7 @@ module Sensu
         resolve = Proc.new do
           begin
             info = case RUBY_PLATFORM
-            when "java"
+            when "java", /mswin|msys|mingw32/
               Socket.getaddrinfo(host, nil)
             else
               flags = Socket::AI_NUMERICSERV | Socket::AI_ADDRCONFIG

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -160,8 +160,9 @@ module Sensu
         resolve = Proc.new do
           begin
             dns = Resolv::DNS.new
-            ip_address = dns.getaddress(host)
-            ip_address.to_s
+            ip_addresses = dns.getaddresses(host)
+            ip_address = ip_addresses.shift
+            ip_address.nil? nil : ip_address.to_s
           rescue => error
             @logger.error("transport connection error", {
               :reason => "unable to resolve hostname",

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -159,9 +159,14 @@ module Sensu
       def resolve_hostname(host, &callback)
         resolve = Proc.new do
           begin
-            flags = Socket::AI_NUMERICSERV | Socket::AI_ADDRCONFIG
-            info = Socket.getaddrinfo(host, nil, Socket::AF_UNSPEC, nil, nil, flags).first
-            info.nil? ? nil : info[2]
+            info = case RUBY_PLATFORM
+            when "java"
+              Socket.getaddrinfo(host, nil)
+            else
+              flags = Socket::AI_NUMERICSERV | Socket::AI_ADDRCONFIG
+              Socket.getaddrinfo(host, nil, Socket::AF_UNSPEC, nil, nil, flags)
+            end
+            info.first.nil? ? nil : info.first[2]
           rescue => error
             @logger.error("transport connection error", {
               :reason => "unable to resolve hostname",

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -162,7 +162,7 @@ module Sensu
             dns = Resolv::DNS.new
             ip_addresses = dns.getaddresses(host)
             ip_address = ip_addresses.shift
-            ip_address.nil? nil : ip_address.to_s
+            ip_address.nil? ? nil : ip_address.to_s
           rescue => error
             @logger.error("transport connection error", {
               :reason => "unable to resolve hostname",

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -160,9 +160,14 @@ module Sensu
         resolve = Proc.new do
           begin
             dns = Resolv::DNS.new
-            ip_addresses = dns.getaddresses(host)
-            ip_address = ip_addresses.shift
-            ip_address.nil? ? nil : ip_address.to_s
+            ip_addresses = []
+            dns.each_resource(host, Resolv::DNS::Resource::IN::A) do |resource|
+              ip_addresses << resource.address.to_s
+            end
+            dns.each_resource(host, Resolv::DNS::Resource::IN::AAAA) do |resource|
+              ip_addresses << resource.address.to_s
+            end
+            ip_addresses.shift
           rescue => error
             @logger.error("transport connection error", {
               :reason => "unable to resolve hostname",

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -1,6 +1,7 @@
 require "eventmachine"
 require "resolv"
 require "ipaddr"
+require "socket"
 
 module Sensu
   module Transport
@@ -167,7 +168,13 @@ module Sensu
             dns.each_resource(host, Resolv::DNS::Resource::IN::AAAA) do |resource|
               ip_addresses << resource.address.to_s
             end
-            ip_addresses.shift
+            ip_address = ip_addresses.shift
+            if ip_address.nil?
+              info = Socket.getaddrinfo(host, nil).first
+              info.nil? ? nil : info[2]
+            else
+              ip_address
+            end
           rescue => error
             @logger.error("transport connection error", {
               :reason => "unable to resolve hostname",

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -168,6 +168,7 @@ module Sensu
             end
             info.first.nil? ? nil : info.first[2]
           rescue => error
+            puts error.to_s
             @logger.error("transport connection error", {
               :reason => "unable to resolve hostname",
               :error => error.to_s

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -160,11 +160,11 @@ module Sensu
         resolve = Proc.new do
           begin
             info = case RUBY_PLATFORM
-            when "java", /mswin|msys|mingw32/
-              Socket.getaddrinfo(host, nil)
-            else
+            when /linux/
               flags = Socket::AI_NUMERICSERV | Socket::AI_ADDRCONFIG
               Socket.getaddrinfo(host, nil, Socket::AF_UNSPEC, nil, nil, flags)
+            else
+              Socket.getaddrinfo(host, nil)
             end
             info.first.nil? ? nil : info.first[2]
           rescue => error

--- a/lib/sensu/transport/base.rb
+++ b/lib/sensu/transport/base.rb
@@ -168,7 +168,6 @@ module Sensu
             end
             info.first.nil? ? nil : info.first[2]
           rescue => error
-            puts error.to_s
             @logger.error("transport connection error", {
               :reason => "unable to resolve hostname",
               :error => error.to_s

--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -193,6 +193,8 @@ module Sensu
               EM::Timer.new(3) do
                 next_connection_options(&callback)
               end
+            elsif ip_address == "::1"
+              yield options
             else
               yield options.merge(:host => ip_address)
             end

--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -189,6 +189,7 @@ module Sensu
         options = @eligible_options.shift
         if options.is_a?(Hash) && options[:host]
           resolve_host(options[:host]) do |ip_address|
+            puts "RESOLVED ADDRESS: #{ip_address}"
             if ip_address.nil?
               EM::Timer.new(3) do
                 next_connection_options(&callback)

--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -189,7 +189,6 @@ module Sensu
         options = @eligible_options.shift
         if options.is_a?(Hash) && options[:host]
           resolve_host(options[:host]) do |ip_address|
-            puts "RESOLVED ADDRESS: #{ip_address}"
             if ip_address.nil?
               EM::Timer.new(3) do
                 next_connection_options(&callback)

--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -194,8 +194,6 @@ module Sensu
               EM::Timer.new(3) do
                 next_connection_options(&callback)
               end
-            elsif ip_address == "::1"
-              yield options
             else
               yield options.merge(:host => ip_address)
             end

--- a/spec/rabbitmq_spec.rb
+++ b/spec/rabbitmq_spec.rb
@@ -40,7 +40,7 @@ describe "Sensu::Transport::RabbitMQ" do
   it "can open a connection using a hostname" do
     async_wrapper do
       @transport.connect(:host => "localhost")
-      timer(1) do
+      timer(2) do
         expect(@transport.connected?).to be(true)
         async_done
       end

--- a/spec/rabbitmq_spec.rb
+++ b/spec/rabbitmq_spec.rb
@@ -37,10 +37,10 @@ describe "Sensu::Transport::RabbitMQ" do
     end
   end
 
-  it "can open a connection using a hostname" do
+  it "can open a connection using a hostname", :dns => true do
     async_wrapper do
       @transport.connect(:host => "localhost")
-      timer(2) do
+      timer(1) do
         expect(@transport.connected?).to be(true)
         async_done
       end

--- a/spec/rabbitmq_spec.rb
+++ b/spec/rabbitmq_spec.rb
@@ -37,6 +37,16 @@ describe "Sensu::Transport::RabbitMQ" do
     end
   end
 
+  it "can open a connection using a hostname" do
+    async_wrapper do
+      @transport.connect(:host => "localhost")
+      timer(1) do
+        expect(@transport.connected?).to be(true)
+        async_done
+      end
+    end
+  end
+
   it "can unsubscribe from queues and close the connection" do
     async_wrapper do
       @transport.connect
@@ -107,17 +117,11 @@ describe "Sensu::Transport::RabbitMQ" do
     end
   end
 
-  it "will throw an error if it cannot resolve a hostname" do
+  it "will not throw an error if it cannot resolve a hostname" do
     async_wrapper do
-      expected_error_class = case RUBY_PLATFORM
-      when "java"
-        Java::JavaNioChannels::UnresolvedAddressException
-      else
-        EventMachine::ConnectionError
-      end
       expect {
         @transport.connect(:host => "2def33c3-cfbb-4993-b5ee-08d47f6d8793")
-      }.to raise_error(expected_error_class)
+      }.to_not raise_error
       async_done
     end
   end


### PR DESCRIPTION
This pull request adds DNS hostname resolution methods to the Transport Base API, allowing Sensu Transports to resolve hostname prior to attempting to connect to a host.