### PR TITLE
Fix RabbitMQ exchange cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ rvm:
 services:
   - rabbitmq
   - redis
+before_install:
+  - gem install bundler --version 1.15.1
 script: "bundle exec rspec . --tag ~ssl"

--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -87,7 +87,7 @@ module Sensu
           previously_declared = @queues.has_key?(funnel)
           @queues[funnel] ||= @channel.queue!(funnel, :auto_delete => true)
           queue = @queues[funnel]
-          queue.bind(@channel.method(type.to_sym).call(pipe))
+          queue.bind(@channel.method(type.to_sym).call(pipe, :auto_delete => true))
           unless previously_declared
             queue.subscribe(options, &callback)
           end


### PR DESCRIPTION
The pull request adds the use of AMQP "auto_delete" with subscription exchanges, the exchanges are now deleted when all queues have finished using them.

These changes are in response to an issue reported by Anatoliy D on the Sensu community slack.

```
Just found that Sensu does not delete rabbitmq exchange when client is deleted.  I see this in my RMQ cluster -  Exchanges: 285191, Queues: 1005 .  Queues corresponds with the number of active clients, exchange list contains all client names since the beginning. Any idea why exchanges are not deleted ?
```

THESE CHANGES ARE NOT BACKWARDS COMPATIBLE! In order to set "auto_delete", the RabbitMQ exchanges must be re-declared, requiring users first manually delete the exchanges or reset the RabbitMQ node(s). This makes the upgrade path more difficult.

The Sensu server be updated to use `:auto_delete => true` and `:passive => true` when publishing check requests to subscriptions.