### PR TITLE
Reconnect after failing to resolve a RabbitMQ hostname

### DIFF
--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -37,7 +37,7 @@ module Sensu
       #
       # @return [TrueClass, FalseClass]
       def connected?
-        @connection.connected?
+        @connection && @connection.connected?
       end
 
       # Close the RabbitMQ connection.
@@ -190,9 +190,7 @@ module Sensu
         if options.is_a?(Hash) && options[:host]
           resolve_host(options[:host]) do |ip_address|
             if ip_address.nil?
-              EM::Timer.new(3) do
-                next_connection_options(&callback)
-              end
+              reconnect
             else
               yield options.merge(:host => ip_address)
             end


### PR DESCRIPTION
A combination of periodic reconnect and separate hostname resolution attempts effectively caused a DOS of a DNS endpoint. 

This pull request leverages the `reconnect()` logic with retry timer backoff. Using reconnect also allows the transport to connect to another eligible broker after failing to resolve a hostname.

Closes https://github.com/sensu/sensu/issues/1798

Signed-off-by: Sean Porter <portertech@gmail.com>