### PR TITLE
Reconnect on publish error

### DIFF
--- a/lib/sensu/transport/rabbitmq.rb
+++ b/lib/sensu/transport/rabbitmq.rb
@@ -75,7 +75,8 @@ module Sensu
             end
           end
         else
-          info = {:error => "Transport is not connected"}
+          info = {:error => "Transport is not connected, triggering reconnect"}
+          reconnect
           yield(info) if block_given?
         end
       end


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Should fix an issue where a reconnect doesn't get triggered after the TCP connection to RabbitMQ dies.